### PR TITLE
Extend get_all_entropies to include CAT_OPTIONS

### DIFF
--- a/viewer_script.py
+++ b/viewer_script.py
@@ -300,7 +300,7 @@ def get_all_entropies(output=False):
 
 	# create dictionary for binarized cat options for each unique entry in options (uid + pid + time)
 	# {unique id : {cat_option_val : bool}}
-	binarized_cat_options_dict = query_cat_to_dict("", {})
+	binarized_cat_options_dict = query_binarize_cat_to_dict("", {})
 	cat_options_dict_per_unique_id = binarized_cat_options_dict.values()
 	num_unique_ids = len(binarized_cat_options_dict.keys())
 	all_cat_option_values = cat_options_dict_per_unique_id[0].keys()
@@ -563,7 +563,7 @@ def query_to_views(where):
 			views[unique_id] = view
 
 	# add CAT options to views dict
-	views = query_cat_to_dict(where, views)
+	views = query_binarize_cat_to_dict(where, views)
 
 	return views
 
@@ -572,7 +572,7 @@ def query_to_views(where):
 #        a dict of bools for options, sorted by key {unique_id : {option : bool}}
 # For each result, add to the given dict of bools each categorical option, sorted by key
 # Output: updated dict (dict of dicts, keys are unique ids = uid + pid + time (concatted))
-def query_cat_to_dict(where, dictionary):
+def query_binarize_cat_to_dict(where, dictionary):
 	for cat_opt in CAT_OPTIONS.keys():
 		c.execute('''select uid, pid, time, %s from options %s''' % (cat_opt, where))
 		results = c.fetchall()

--- a/viewer_script.py
+++ b/viewer_script.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 try: input = raw_input
 except NameError: pass
 
-ENTROPIES_FILE = "binary_entropies.csv" # TODO, after get_all_entropies handles CAT options, should just be entropies.csv
+ENTROPIES_FILE = "entropies.csv"
 
 """
 VIEW (conceptual struct):

--- a/viewer_script.py
+++ b/viewer_script.py
@@ -324,6 +324,49 @@ def get_all_entropies(output=False):
 		for option, en in sorted_dict:
 			print(option + "," + str(en))
 
+
+# ------------ WRITE TO CSV FUNCTIONS -----------------
+
+# Input: a list of dictionaries of {column name : val} for each entry in the desired table
+# to create, the name of the csv file to create
+# Output: creates a csv file from the given dictionary data
+def write_csv_from_dict(dict_data, name):
+	csv_file_name = name
+	csv_columns = dict_data[0].keys()
+	try:
+		with open(csv_file_name, 'w') as csvfile:
+			writer = csv.DictWriter(csvfile, fieldnames=csv_columns)
+			writer.writeheader()
+			for data in dict_data:
+				writer.writerow(data)
+	except IOError:
+		raise Exception("I/O error")
+
+
+# Input: where query for query_to_views
+# Output: creates a csv file for the options data containing relevant columns for
+# viewing/visualization and hierarchical clustering
+def write_options_csv(where):
+
+	options_views_dicts = query_to_views(where)
+	options_csv_dict = {}
+
+	c.execute('''select uid, pid, time from options %s''' % where)
+	results = c.fetchall()
+
+	for result in results:
+		uid = result[0]
+		pid = result[1]
+		time = result[2]
+		unique_id = str(uid) + str(pid) + str(time)
+		options_csv_dict[unique_id] = {"uid": uid, "pid": pid, "time": time}
+		options_csv_dict[unique_id].update(options_views_dicts[unique_id])
+
+	dict_data = options_csv_dict.values()
+	write_csv_from_dict(dict_data, "options_view.csv")
+	print("Created options_view csv")
+
+
 # ------------ CLEAN DATABASE -----------------
 
 
@@ -790,6 +833,9 @@ def io_mode(args):
 
 		if command == "clean":
 			clean_db()
+
+		if command == "csv options":
+			write_options_csv("")
 
 		if command == "ent all":
 			get_all_entropies(output=True)

--- a/viewer_script.py
+++ b/viewer_script.py
@@ -548,6 +548,18 @@ def query_to_views(where):
 			#	print(bin_opt)
 			view[bin_opt] = result[3]
 			views[unique_id] = view
+
+	# add CAT options to views dict
+	views = query_cat_to_views(where, views)
+
+	return views
+
+
+# Input: string of where queries for options table (e.g. "where uid=... and pid=....") and
+#        a view dict of bools for options, sorted by key {unique_id : {option : bool}}
+# For each result, add to the given view dict of bools each categorical option, sorted by key
+# Output: updated dict of views (dict of dicts, keys are unique ids = uid + pid + time (concatted))
+def query_cat_to_views(where, views):
 	for cat_opt in CAT_OPTIONS.keys():
 		c.execute('''select uid, pid, time, %s from options %s''' % (cat_opt, where))
 		results = c.fetchall()
@@ -563,7 +575,8 @@ def query_to_views(where):
 					view[opt] = 0
 			views[unique_id] = view
 	return views
-	
+
+
 # convert unicode to ints, the hardcoded way
 def unicode_clean(cluster):
 	for i in range(len(cluster)):


### PR DESCRIPTION
Addresses issue #12 
- abstracted binarizing cat options to a helper function
- added binarized cat options to get_all_entropies
- updated entropy function to account for scenario when p = 0 or 1
